### PR TITLE
Fix local install

### DIFF
--- a/legal-semantic-search/README.md
+++ b/legal-semantic-search/README.md
@@ -54,7 +54,7 @@ Log into [the Voyage AI dashboard](https://dash.voyageai.com/) and create a new 
 From the project root directory, run the following command.
 
 ```bash
-cd legal-semantic-search && npm install 
+cd legal-semantic-search && npm install --force
 ```
 
 Make sure you have populated the client `.env` with relevant keys.

--- a/legal-semantic-search/package.json
+++ b/legal-semantic-search/package.json
@@ -22,7 +22,7 @@
     "langchain": "^0.2.3",
     "lucide-react": "^0.381.0",
     "next": "14.2.3",
-    "openai": "link:langchain/llms/openai",
+    "openai": "file:langchain/llms/openai",
     "p-limit": "^5.0.0",
     "pdf-parse": "^1.1.1",
     "peggy": "^4.0.2",
@@ -31,7 +31,7 @@
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "uuid": "^9.0.1",
-    "voyage": "link:langchain/embeddings/voyage"
+    "voyage": "file:langchain/embeddings/voyage"
   },
   "devDependencies": {
     "@types/node": "^20",

--- a/legal-semantic-search/src/app/services/bootstrap.ts
+++ b/legal-semantic-search/src/app/services/bootstrap.ts
@@ -50,7 +50,7 @@ const batchUpserts = async (index: any, vectors: any[], batchSize: number = 50) 
 
 export const initiateBootstrapping = async (targetIndex: string) => {
 
-  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : 'http://localhost:3000';
+  const baseUrl = process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : `http://localhost:${process.env.PORT}`;
 
   // Initiate a POST request with fetch to the /ingest endpoint, in order to begin 
   // chunking, embedding and upserting documents that will form the knowledge base


### PR DESCRIPTION
## Problem

When installed locally through the npx command, there are currently two errors blocking forward progress: 
1. The npm install command fails due to outdated link syntax
2. The bootstrap API call CAN fail if you're not running on exactly port `3000`

## Solution

1. Update package.json link syntax
2. Dynamically read the port the app is running on from the environment 

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

Describe specific steps for validating this change.
