### PR TITLE
Fixed input arg count issue with get_embedding_request_data utility function

### DIFF
--- a/shop-the-look/api/config.py
+++ b/shop-the-look/api/config.py
@@ -76,7 +76,7 @@ class Settings:
             print(f"Error getting access token: {str(e)}")
             return None
 
-    def get_embedding_request_data(access_token, content_type, content):
+    def get_embedding_request_data(self, access_token, content_type, content):
         """
         Prepares the request data for the multimodal embedding API.
 
@@ -85,7 +85,7 @@ class Settings:
         :param content: The actual content (query string for text, base64 encoded string for image/video)
         :return: A tuple containing the URL, headers, and data for the API request
         """
-        url = f"https://{settings.location}-aiplatform.googleapis.com/v1/projects/{settings.project_id}/locations/{settings.location}/publishers/google/models/multimodalembedding@001:predict"
+        url = f"https://{self.location}-aiplatform.googleapis.com/v1/projects/{self.project_id}/locations/{self.location}/publishers/google/models/multimodalembedding@001:predict"
         
         headers = {
             "Authorization": f"Bearer {access_token}",
@@ -105,5 +105,4 @@ class Settings:
         }
 
         return url, headers, data
-
 settings = Settings()

--- a/shop-the-look/api/v1/endpoints/text.py
+++ b/shop-the-look/api/v1/endpoints/text.py
@@ -19,14 +19,6 @@ async def query_text(query: TextQuery):
 
         url, headers, data = settings.get_embedding_request_data(access_token, 'text', query.query)
 
-        data = {
-            "instances": [
-                {
-                    "text": query.query
-                }
-            ]
-        }
-
         response = requests.post(url, headers=headers, json=data)
         response.raise_for_status()
 

--- a/shop-the-look/app/styles.css
+++ b/shop-the-look/app/styles.css
@@ -1,9 +1,6 @@
-/* styles.css */
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* styles.css */
 
 .tooltip {
   position: relative;


### PR DESCRIPTION
## Problem

Fixed an issue where I omitted `self` into input arg of the get_embedding_request_data utility function

## Solution

Encountered this error after deploying to Vercel in the add-shop-the-look branch
![image](https://github.com/user-attachments/assets/2bad695d-ad56-4faf-a9ec-f859e7b90d04)

Fixed it by adding `self` back into the input args of the offending utility function

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

I tested on localhost and it fixes the problem. Will double check once deployed to Vercel. 
