### PR TITLE
Reduce height of chat window so it fits better in iframe

### DIFF
--- a/pinecone-assistant/src/app/home.tsx
+++ b/pinecone-assistant/src/app/home.tsx
@@ -187,7 +187,7 @@ export default function Home({ initialShowAssistantFiles, showCitations }: HomeP
           <h1 className="text-2xl font-bold mb-4 text-indigo-900 dark:text-indigo-100"><a href="https://www.pinecone.io/blog/pinecone-assistant/" target="_blank" rel="noopener noreferrer" className="hover:underline">Pinecone Assistant</a>: {assistantName} <span className="text-green-500">●</span></h1>
           <div className="flex flex-col gap-4">
             <div className="w-full">
-              <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg mb-4 h-[calc(100vh-500px)] overflow-y-auto">
+              <div className="bg-white dark:bg-gray-800 p-4 rounded-lg shadow-lg mb-4 h-[calc(100vh-650px)] overflow-y-auto">
                 {messages.map((message, index) => (
                   <div key={index} className={`mb-2 flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}>
                     <div className={`flex items-start ${message.role === 'user' ? 'flex-row-reverse' : 'flex-row'}`}>


### PR DESCRIPTION
## Problem

We got a report from @krugster that the chat window height was too tall in the iframed demo on the docs, causing the UI to be unwieldy. 

## Solution

Shrink the height of the chat window by 150px.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Infrastructure change (CI configs, etc)
- [ ] Non-code change (docs, etc)
- [ ] None of the above: (explain here)

## Test Plan

This change has been validated locally and will be validated in a preview environment and production.
