### PR TITLE
security: fix Dependabot alert #599 — bump pytest to 9.0.3

### DIFF
--- a/shop-the-look/requirements-dev.txt
+++ b/shop-the-look/requirements-dev.txt
@@ -1,3 +1,3 @@
 # Test-only dependencies for the execution-based smoke gate (see TESTING.md).
-pytest==8.3.4
+pytest==9.0.3
 httpx==0.28.1


### PR DESCRIPTION
## Summary
Fixes [Dependabot alert #599](https://github.com/pinecone-io/sample-apps/security/dependabot/599) (`GHSA-6w46-j5rx-g56g` / `CVE-2025-71176`, **medium**).

`pytest` before 9.0.3 relies on the predictable `/tmp/pytest-of-{user}` tmpdir pattern (CWE-379), which lets a local user cause a DoS or potentially gain privileges. Bumps the dev-only dependency in `shop-the-look/requirements-dev.txt` from `8.3.4` → `9.0.3` (first patched version).

## Testing
Reproduced the CI api smoke gate locally on Python 3.11:
```
python -m pytest tests/ -q
1 passed
```
Dev-only dependency — no runtime/app code affected.