### PR TITLE
chore: bump video.js to ^8.24.0 in shop-the-look

### DIFF
--- a/shop-the-look/package-lock.json
+++ b/shop-the-look/package-lock.json
@@ -23,7 +23,7 @@
         "react-dom": "18.2.0",
         "tailwindcss": "3.3.2",
         "typescript": "5.0.4",
-        "video.js": "^8.12.0"
+        "video.js": "^8.24.0"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -1979,17 +1979,17 @@
       }
     },
     "node_modules/@videojs/http-streaming": {
-      "version": "3.17.4",
-      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.17.4.tgz",
-      "integrity": "sha512-XAvdG2dolBuV2Fx8bu1kjmQ2D4TonGzZH68Pgv/O9xMSFWdZtITSMFismeQLEAtMmGwze8qNJp3RgV+jStrJqg==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/@videojs/http-streaming/-/http-streaming-3.17.5.tgz",
+      "integrity": "sha512-PRRQVu0hYW5h0XvRWpIyIpEatpMZzZtf7L1avV89Hnu+69f+0c7oLsSL9jwpg2nbvzGkdX5rQxQkz5Vc7tFR9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^4.1.1",
+        "@videojs/vhs-utils": "^4.1.2",
         "aes-decrypter": "^4.0.2",
         "global": "^4.4.0",
         "m3u8-parser": "^7.2.0",
-        "mpd-parser": "^1.3.1",
+        "mpd-parser": "^1.4.0",
         "mux.js": "7.1.0",
         "video.js": "^7 || ^8"
       },
@@ -2002,9 +2002,9 @@
       }
     },
     "node_modules/@videojs/vhs-utils": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.1.tgz",
-      "integrity": "sha512-5iLX6sR2ownbv4Mtejw6Ax+naosGvoT9kY+gcuHzANyUZZ+4NpeNdKMUhb6ag0acYej1Y7cmr/F2+4PrggMiVA==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@videojs/vhs-utils/-/vhs-utils-4.1.2.tgz",
+      "integrity": "sha512-1Dsv5dtWOq0LP1G37O46FQFA2tKAZON5UMe6dFPxT7JvPhEx8QIXcFQxan8+hHI3fX6aomFRFrUBJNgRYQDSXA==",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
@@ -2027,9 +2027,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.10",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
-      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "version": "0.9.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.11.tgz",
+      "integrity": "sha512-tW8bcK3hsG0/uqSnNz6TK4BkcuZSezoU7DlnYssILmZDktPnSHHuDJJFM0AJv+13gz2r0iGdrj6qqKeUnxXEDg==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -4936,13 +4936,13 @@
       }
     },
     "node_modules/mpd-parser": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.3.1.tgz",
-      "integrity": "sha512-1FuyEWI5k2HcmhS1HkKnUAQV7yFPfXPht2DnRRGtoiiAAW+ESTbtEXIDpRkwdU+XyrQuwrIym7UkoPKsZ0SyFw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mpd-parser/-/mpd-parser-1.4.0.tgz",
+      "integrity": "sha512-blbA7XpAaOdC/PR0Tu8GiUxlx6CpBuRowQPYV7lhi9Yr9G9+dkPXIUjqjzc/NCn/uZZPopluaJlIYntIEI/VLw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
-        "@videojs/vhs-utils": "^4.0.0",
+        "@videojs/vhs-utils": "^4.1.2",
         "@xmldom/xmldom": "^0.8.3",
         "global": "^4.4.0"
       },
@@ -6738,19 +6738,19 @@
       "license": "MIT"
     },
     "node_modules/video.js": {
-      "version": "8.23.7",
-      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.23.7.tgz",
-      "integrity": "sha512-cG4HOygYt+Z8j6Sf5DuK6OgEOoM+g9oGP6vpqoZRaD13aHE4PMITbyjJUXZcIQbgB0wJEadBRaVm5lJIzo2jAA==",
+      "version": "8.24.0",
+      "resolved": "https://registry.npmjs.org/video.js/-/video.js-8.24.0.tgz",
+      "integrity": "sha512-ZUuxTlDRkEWhpp2mvGCSFzI0Tc3zcC6IUZbIhBcZ3QW0Ms+IRp/tzYkhqexcMYwrcukRFiWWJmRANsLKvv8Vsg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
-        "@videojs/http-streaming": "^3.17.3",
-        "@videojs/vhs-utils": "^4.1.1",
+        "@videojs/http-streaming": "^3.17.5",
+        "@videojs/vhs-utils": "^4.1.2",
         "@videojs/xhr": "2.7.0",
         "aes-decrypter": "^4.0.2",
         "global": "4.4.0",
         "m3u8-parser": "^7.2.0",
-        "mpd-parser": "^1.3.1",
+        "mpd-parser": "^1.4.0",
         "mux.js": "^7.0.1",
         "videojs-contrib-quality-levels": "4.1.0",
         "videojs-font": "4.2.0",

--- a/shop-the-look/package.json
+++ b/shop-the-look/package.json
@@ -26,7 +26,7 @@
     "react-dom": "18.2.0",
     "tailwindcss": "3.3.2",
     "typescript": "5.0.4",
-    "video.js": "^8.12.0"
+    "video.js": "^8.24.0"
   },
   "overrides": {
     "cross-spawn": "^7.0.6",


### PR DESCRIPTION
## What

Bumps `video.js` from `^8.12.0` to `^8.24.0` in the `shop-the-look` sample app (latest within the v8 major).

## Why

Routine dependency maintenance. `video.js` is a runtime dependency used in `shop-the-look/app/page.tsx`. Staying current within the major picks up bug/security fixes with no breaking-change risk.

## Verification

- `npm install` — clean, **0 vulnerabilities**
- `npm run build` — ✓ compiled successfully (Next.js 16.3.0)
- `npm run start` — server boots, `/` returns HTTP 200

The pre-existing TypeScript-version advisory (5.0.4 vs recommended 5.1.0) is unrelated to this change.