### PR TITLE
chore: bump langchain to ^1.5.6 in legal-semantic-search

### DIFF
--- a/legal-semantic-search/package-lock.json
+++ b/legal-semantic-search/package-lock.json
@@ -18,7 +18,7 @@
         "@types/uuid": "^9.0.8",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
-        "langchain": "^1.5.5",
+        "langchain": "^1.5.6",
         "lucide-react": "^0.381.0",
         "next": "16.3.0",
         "openai": "file:langchain/llms/openai",
@@ -5582,9 +5582,9 @@
       }
     },
     "node_modules/langchain": {
-      "version": "1.5.5",
-      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.5.5.tgz",
-      "integrity": "sha512-KhedvQDRvaLIFMSvEy45U/pqR4G0dEfN7wPyHTBMgMIUXbcrVkaqRVlDSMPfMCwNuiRCfWFUHueYGtgSrwBcBA==",
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/langchain/-/langchain-1.5.6.tgz",
+      "integrity": "sha512-QJhvXn6a9OKK2kwQBBHbOSh/uAPwqoYa78enkCcn/78cJEfHJTQD9xFmtxSY1DFZ36LH5dz+vrjT0OsU3pO3mw==",
       "license": "MIT",
       "dependencies": {
         "@langchain/langgraph": "^1.4.8",
@@ -5596,7 +5596,7 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@langchain/core": "^1.2.5"
+        "@langchain/core": "^1.2.6"
       }
     },
     "node_modules/langsmith": {

--- a/legal-semantic-search/package.json
+++ b/legal-semantic-search/package.json
@@ -19,7 +19,7 @@
     "@types/uuid": "^9.0.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
-    "langchain": "^1.5.5",
+    "langchain": "^1.5.6",
     "lucide-react": "^0.381.0",
     "next": "16.3.0",
     "openai": "file:langchain/llms/openai",


### PR DESCRIPTION
## What

Bumps `langchain` from `^1.5.5` to `^1.5.6` in the `legal-semantic-search` sample app (latest patch within the v1 major).

## Why

Routine dependency maintenance. `langchain` is a core runtime dependency of this app. Staying current on patch releases within the major picks up bug fixes with no breaking-change risk.

## Verification

Matched the CI recipe locally (`--legacy-peer-deps` install, dummy Pinecone/Voyage env):

- `npm install --legacy-peer-deps` — clean, **0 vulnerabilities**
- `npm run build` — ✓ compiled + typechecked (Next.js 16.3.0)
- `npx next start` — server boots, `/` returns HTTP 200