### PR TITLE
chore: bump multer to ^2.2.0 in namespace-notes server

### DIFF
--- a/namespace-notes/server/package-lock.json
+++ b/namespace-notes/server/package-lock.json
@@ -24,7 +24,7 @@
         "express": "^4.22.0",
         "express-rate-limit": "^7.4.1",
         "mime": "^4.0.1",
-        "multer": "^2.0.2",
+        "multer": "^2.2.0",
         "openai": "^4.29.0",
         "pdf-parse": "^1.1.1",
         "uuid": "^11.1.1"

--- a/namespace-notes/server/package.json
+++ b/namespace-notes/server/package.json
@@ -28,7 +28,7 @@
     "express": "^4.22.0",
     "express-rate-limit": "^7.4.1",
     "mime": "^4.0.1",
-    "multer": "^2.0.2",
+    "multer": "^2.2.0",
     "openai": "^4.29.0",
     "pdf-parse": "^1.1.1",
     "uuid": "^11.1.1"


### PR DESCRIPTION
## What

Bumps `multer` from `^2.0.2` to `^2.2.0` in the `namespace-notes` server (latest within the v2 major).

## Why

Routine dependency maintenance. `multer` handles multipart file uploads in the server (`src/utils/multer.ts`, `src/controllers/documentController.ts`) — keeping it current within the major picks up parsing/security fixes with no breaking-change risk.

## Verification

Matched the CI recipe locally:

- `npm install --include=dev` — clean, **0 vulnerabilities**
- `npm run build` (install + `tsc`) — ✓ compiles, emits `dist/index.js`
- Boot smoke — `node dist/index.js` starts, binds port, routes a request (HTTP 500 as expected: the handler is Pinecone-gated with a dummy key; "any HTTP response = alive" per the CI smoke definition)