### PR TITLE
chore: bump react-markdown to ^9.1.0 in pinecone-assistant

### DIFF
--- a/pinecone-assistant/package.json
+++ b/pinecone-assistant/package.json
@@ -14,7 +14,7 @@
     "next": "16.3.0",
     "react": "^18",
     "react-dom": "^18",
-    "react-markdown": "^9.0.1",
+    "react-markdown": "^9.1.0",
     "uuid": "^11.1.1",
     "zod": "^3.25.76"
   },

--- a/pinecone-assistant/pnpm-lock.yaml
+++ b/pinecone-assistant/pnpm-lock.yaml
@@ -36,7 +36,7 @@ importers:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
       react-markdown:
-        specifier: ^9.0.1
+        specifier: ^9.1.0
         version: 9.1.0(@types/react@18.3.29)(react@18.3.1)
       uuid:
         specifier: ^11.1.1
@@ -3351,7 +3351,7 @@ snapshots:
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 7.1.1(eslint@8.57.1)
@@ -3384,7 +3384,7 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -3399,7 +3399,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.67.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9


### PR DESCRIPTION
## What

Bumps `react-markdown` from `^9.0.1` to `^9.1.0` in the `pinecone-assistant` sample app (latest within the v9 major).

## Why

Routine dependency maintenance. `react-markdown` renders assistant responses in `src/app/home.tsx`. Staying current within the major picks up bug fixes with no breaking-change risk.

## Verification

Matched the CI recipe locally (repo-pinned pnpm 9, `NPM_CONFIG_VERIFY_DEPS_BEFORE_RUN=false`):

- `pnpm install` — lockfile updated (react-markdown resolves to 9.1.0; a few `eslint-plugin-import` peer-dep keys re-normalized by pnpm 9, same resolution)
- `pnpm run build` — ✓ compiled + typechecked (Next.js 16.3.0)
- `pnpm exec next start` — server boots, `/` returns HTTP 200