### PR TITLE
chore: bump react-icons to ^5.7.0 in namespace-notes client

### DIFF
--- a/namespace-notes/client/package-lock.json
+++ b/namespace-notes/client/package-lock.json
@@ -39,7 +39,7 @@
         "openai": "^4.24.7",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-icons": "^5.0.1",
+        "react-icons": "^5.7.0",
         "react-intersection-observer": "^9.5.3",
         "react-markdown": "^8.0.7",
         "react-syntax-highlighter": "^16.1.1",
@@ -9637,9 +9637,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.6.0.tgz",
-      "integrity": "sha512-RH93p5ki6LfOiIt0UtDyNg/cee+HLVR6cHHtW3wALfo+eOHTp8RnU2kRkI6E+H19zMIs03DyxUG/GfZMOGvmiA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.7.0.tgz",
+      "integrity": "sha512-LBLy340Rzqy6+/yVhZKT3B/QpP1BZaesGqasf09HPOBzRarcDIFH0WwXlXQfE7q7ipxK4MSiC5DIBWURCny6fw==",
       "license": "MIT",
       "peerDependencies": {
         "react": "*"

--- a/namespace-notes/client/package.json
+++ b/namespace-notes/client/package.json
@@ -40,7 +40,7 @@
     "openai": "^4.24.7",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^5.0.1",
+    "react-icons": "^5.7.0",
     "react-intersection-observer": "^9.5.3",
     "react-markdown": "^8.0.7",
     "react-syntax-highlighter": "^16.1.1",


### PR DESCRIPTION
## What

Bumps `react-icons` from `^5.0.1` to `^5.7.0` in the `namespace-notes` client (latest within the v5 major).

## Why

Routine dependency maintenance. `react-icons` supplies UI icons used across 4 client files. Staying current within the major picks up new icon sets and fixes with no breaking-change risk.

## Verification

Matched the CI recipe locally (`--legacy-peer-deps`, dummy Pinecone key):

- `npm install --legacy-peer-deps` — clean, **0 vulnerabilities**
- `npm run build` — ✓ compiled + typechecked (Next.js 16.3.0)
- `npx next start` — server boots, `/` returns HTTP 200