### PR TITLE
chore: bump express-rate-limit to ^7.5.1 in namespace-notes server

### DIFF
--- a/namespace-notes/server/package-lock.json
+++ b/namespace-notes/server/package-lock.json
@@ -22,7 +22,7 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
         "express": "^4.22.0",
-        "express-rate-limit": "^7.4.1",
+        "express-rate-limit": "^7.5.1",
         "mime": "^4.0.1",
         "multer": "^2.2.0",
         "openai": "^4.29.0",

--- a/namespace-notes/server/package.json
+++ b/namespace-notes/server/package.json
@@ -26,7 +26,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
     "express": "^4.22.0",
-    "express-rate-limit": "^7.4.1",
+    "express-rate-limit": "^7.5.1",
     "mime": "^4.0.1",
     "multer": "^2.2.0",
     "openai": "^4.29.0",


### PR DESCRIPTION
## What

Bumps `express-rate-limit` from `^7.4.1` to `^7.5.1` in the `namespace-notes` server (latest within the v7 major).

## Why

Routine dependency maintenance. `express-rate-limit` enforces request rate limiting in `src/routes/documentRoutes.ts` (a security control added in #78). Staying current within the major picks up fixes with no breaking-change risk.

## Verification

Matched the CI recipe locally:

- `npm install --include=dev` — clean, **0 vulnerabilities**
- `npm run build` (install + `tsc`) — ✓ compiles, emits `dist/index.js`
- Boot smoke — `node dist/index.js` starts, binds port, routes a request (HTTP 500 as expected: Pinecone-gated with a dummy key; "any HTTP response = alive" per the CI smoke definition)