### PR TITLE
chore: bump axios to ^1.19.0 in shop-the-look

### DIFF
--- a/shop-the-look/package-lock.json
+++ b/shop-the-look/package-lock.json
@@ -13,7 +13,7 @@
         "@types/react-dom": "18.2.4",
         "@vercel/analytics": "^1.3.1",
         "autoprefixer": "10.4.14",
-        "axios": "^1.16.1",
+        "axios": "^1.19.0",
         "concurrently": "^8.0.1",
         "eslint": "^9.0.0",
         "eslint-config-next": "16.3.0",

--- a/shop-the-look/package.json
+++ b/shop-the-look/package.json
@@ -16,7 +16,7 @@
     "@types/react-dom": "18.2.4",
     "@vercel/analytics": "^1.3.1",
     "autoprefixer": "10.4.14",
-    "axios": "^1.16.1",
+    "axios": "^1.19.0",
     "concurrently": "^8.0.1",
     "eslint": "^9.0.0",
     "eslint-config-next": "16.3.0",


### PR DESCRIPTION
## What

Bumps `axios` from `^1.16.1` to `^1.19.0` in the `shop-the-look` sample app (latest within the v1 major).

## Why

Routine dependency maintenance. `axios` is used for HTTP requests in `app/page.tsx` and `app/components/FileUploadHandler.tsx`. Staying current within the major picks up bug/security fixes with no breaking-change risk.

## Verification

- `npm install` — clean, **0 vulnerabilities**; lockfile updated (kept `npm ci`-consistent)
- `npm run build` — ✓ compiled (Next.js 16.3.0)
- `npm run start` — server boots, `/` returns HTTP 200