### PR TITLE
chore: bump tailwind-merge to ^2.6.1 in namespace-notes client

### DIFF
--- a/namespace-notes/client/package-lock.json
+++ b/namespace-notes/client/package-lock.json
@@ -47,7 +47,7 @@
         "remark-gfm": "^3.0.1",
         "remark-math": "^5.1.1",
         "sonner": "^1.4.3",
-        "tailwind-merge": "^2.2.2",
+        "tailwind-merge": "^2.6.1",
         "usehooks-ts": "^2.16.0",
         "uuid": "^11.1.1",
         "zod": "^3.25.76"
@@ -69,7 +69,7 @@
         "eslint-plugin-tailwindcss": "^3.14.0",
         "postcss": "^8.5.26",
         "prettier": "^3.2.4",
-        "tailwind-merge": "^2.2.0",
+        "tailwind-merge": "^2.6.1",
         "tailwindcss": "^3.4.1",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.3.3"

--- a/namespace-notes/client/package.json
+++ b/namespace-notes/client/package.json
@@ -48,7 +48,7 @@
     "remark-gfm": "^3.0.1",
     "remark-math": "^5.1.1",
     "sonner": "^1.4.3",
-    "tailwind-merge": "^2.2.2",
+    "tailwind-merge": "^2.6.1",
     "usehooks-ts": "^2.16.0",
     "uuid": "^11.1.1",
     "zod": "^3.25.76"
@@ -70,7 +70,7 @@
     "eslint-plugin-tailwindcss": "^3.14.0",
     "postcss": "^8.5.26",
     "prettier": "^3.2.4",
-    "tailwind-merge": "^2.2.0",
+    "tailwind-merge": "^2.6.1",
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.3.3"


### PR DESCRIPTION
## What

Bumps `tailwind-merge` from `^2.2.x` to `^2.6.1` in the `namespace-notes` client (latest within the v2 major). Updates both the `dependencies` and `devDependencies` entries (a pre-existing duplicate listing) so the declared floors stay consistent.

## Why

Routine dependency maintenance. `tailwind-merge` backs the `cn()` class-merging helper used in `src/lib/utils.ts` and `src/components/chat/utils/utils.ts`. Staying current within the major picks up Tailwind class-conflict fixes with no breaking-change risk.

## Verification

Matched the CI recipe locally (`--legacy-peer-deps`, dummy Pinecone key):

- `npm install --legacy-peer-deps` — clean, **0 vulnerabilities**
- `npm run build` — ✓ compiled + typechecked (Next.js 16.3.0)
- `npx next start` — server boots, `/` returns HTTP 200