### PR TITLE
chore: bump cors to ^2.8.6 in namespace-notes server

### DIFF
--- a/namespace-notes/server/package-lock.json
+++ b/namespace-notes/server/package-lock.json
@@ -19,7 +19,7 @@
         "ai": "^7.0.64",
         "axios": "^1.16.1",
         "body-parser": "^1.20.3",
-        "cors": "^2.8.5",
+        "cors": "^2.8.6",
         "dotenv": "^16.4.5",
         "express": "^4.22.0",
         "express-rate-limit": "^7.5.1",

--- a/namespace-notes/server/package.json
+++ b/namespace-notes/server/package.json
@@ -23,7 +23,7 @@
     "ai": "^7.0.64",
     "axios": "^1.16.1",
     "body-parser": "^1.20.3",
-    "cors": "^2.8.5",
+    "cors": "^2.8.6",
     "dotenv": "^16.4.5",
     "express": "^4.22.0",
     "express-rate-limit": "^7.5.1",


### PR DESCRIPTION
## What

Bumps `cors` from `^2.8.5` to `^2.8.6` in the `namespace-notes` server (latest within the v2 major).

## Why

Routine dependency maintenance. `cors` is the Express CORS middleware applied in `src/index.ts` (`app.use(cors())`). This is a small patch release within the major with no breaking-change risk.

## Verification

Matched the CI recipe locally:

- `npm install --include=dev` — clean, **0 vulnerabilities**
- `npm run build` (install + `tsc`) — ✓ compiles, emits `dist/index.js`
- Boot smoke — `node dist/index.js` starts, binds port, routes a request (HTTP 500 as expected: Pinecone-gated with a dummy key; "any HTTP response = alive" per the CI smoke definition)