### PR TITLE
chore: bump @aws-sdk/* to latest v3 in namespace-notes server

### DIFF
--- a/namespace-notes/server/package-lock.json
+++ b/namespace-notes/server/package-lock.json
@@ -10,9 +10,9 @@
       "license": "ISC",
       "dependencies": {
         "@airbnb/node-memwatch": "^2.0.0",
-        "@aws-sdk/client-s3": "^3.894.0",
-        "@aws-sdk/lib-storage": "^3.894.0",
-        "@aws-sdk/types": "^3.894.0",
+        "@aws-sdk/client-s3": "^3.1109.0",
+        "@aws-sdk/lib-storage": "^3.1109.0",
+        "@aws-sdk/types": "^3.974.3",
         "@pinecone-database/pinecone": "^2.1.0",
         "@types/multer": "^1.4.11",
         "@vercel/blob": "^2.4.0",
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.1108.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1108.0.tgz",
-      "integrity": "sha512-prdothEAFE1G8H0s0+zFGuNZdSj+Acg/siB1dFxPS181op9+hJ1GLr+b2anJch4B9a/xbWy7k8eG/enH3cNSjQ==",
+      "version": "3.1109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1109.0.tgz",
+      "integrity": "sha512-iPWzBeGkAe5H5+dBBGCOdIT4uMhpu12OK+nFnDzjvOChVnHIws4LeoG7Yl0kJHSRWZnNEkVcF4vQYTJny0e5xA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/checksums": "^3.1000.27",
@@ -324,9 +324,9 @@
       }
     },
     "node_modules/@aws-sdk/lib-storage": {
-      "version": "3.1108.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1108.0.tgz",
-      "integrity": "sha512-2hq5FL7oXIHW/m9VASuEL9f7Z67jzXy1g5lEfxGs5sWnAB9GtueY/Bn26lcsSWun/p5T5phXRrLZN9uBvcuP5w==",
+      "version": "3.1109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.1109.0.tgz",
+      "integrity": "sha512-l05ablXGuiLHmuhQZhisBQcK1ZgwP1CsTeb+7x9X942qP9ba6RAMqSfh8R7QGTkN5c9PowWfDVLNbouQDTrQiw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/core": "^3.31.1",
@@ -340,7 +340,7 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@aws-sdk/client-s3": "^3.1108.0"
+        "@aws-sdk/client-s3": "^3.1109.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {

--- a/namespace-notes/server/package.json
+++ b/namespace-notes/server/package.json
@@ -14,9 +14,9 @@
   "license": "ISC",
   "dependencies": {
     "@airbnb/node-memwatch": "^2.0.0",
-    "@aws-sdk/client-s3": "^3.894.0",
-    "@aws-sdk/lib-storage": "^3.894.0",
-    "@aws-sdk/types": "^3.894.0",
+    "@aws-sdk/client-s3": "^3.1109.0",
+    "@aws-sdk/lib-storage": "^3.1109.0",
+    "@aws-sdk/types": "^3.974.3",
     "@pinecone-database/pinecone": "^2.1.0",
     "@types/multer": "^1.4.11",
     "@vercel/blob": "^2.4.0",


### PR DESCRIPTION
## What

Bumps the AWS SDK v3 packages in the `namespace-notes` server to their latest v3 releases (all within the v3 major):

- `@aws-sdk/client-s3` `^3.894.0` → `^3.1109.0`
- `@aws-sdk/lib-storage` `^3.894.0` → `^3.1109.0`
- `@aws-sdk/types` `^3.894.0` → `^3.974.3`

These three ship as a version-aligned family, so they're bumped together as one coherent SDK update.

## Why

Routine dependency maintenance. The AWS SDK backs S3-compatible object storage in `src/utils/storage/spacesStorage.ts` (`client-s3` + `lib-storage`). Staying current within the major picks up fixes with no breaking-change risk.

## Verification

Matched the CI recipe locally:

- `npm install --include=dev` — clean, **0 vulnerabilities**
- `npm run build` (install + `tsc`) — ✓ compiles, emits `dist/index.js`
- Boot smoke — `node dist/index.js` starts, binds port, routes a request (HTTP 500 as expected: Pinecone-gated with a dummy key; "any HTTP response = alive" per the CI smoke definition)