### PR TITLE
feat: upgrade Pinecone client to ^5.1.2 in legal-semantic-search

### DIFF
--- a/legal-semantic-search/package-lock.json
+++ b/legal-semantic-search/package-lock.json
@@ -14,7 +14,7 @@
         "@langchain/openai": "^1.5.6",
         "@langchain/pinecone": "^1.0.3",
         "@langchain/textsplitters": "^1.0.1",
-        "@pinecone-database/pinecone": "^4.1.0",
+        "@pinecone-database/pinecone": "^5.1.2",
         "@types/uuid": "^9.0.8",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
@@ -2151,9 +2151,9 @@
       }
     },
     "node_modules/@pinecone-database/pinecone": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-4.1.0.tgz",
-      "integrity": "sha512-WoVsbvmCgvZfjm/nCasJXuQ/tw0es5BpedLHvRScAm6xJ/nL07s3B0TrsM8m8rACTiUgbdYsdLY1W6cEBhS9xA==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@pinecone-database/pinecone/-/pinecone-5.1.2.tgz",
+      "integrity": "sha512-z7737KUA1hXwd508q1+o4bnRxj0NpMmzA2beyaFm7Y+EC2TYLT5ABuYsn/qhiwiEsYp8v1qS596eBhhvgNagig==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"

--- a/legal-semantic-search/package.json
+++ b/legal-semantic-search/package.json
@@ -15,7 +15,7 @@
     "@langchain/openai": "^1.5.6",
     "@langchain/pinecone": "^1.0.3",
     "@langchain/textsplitters": "^1.0.1",
-    "@pinecone-database/pinecone": "^4.1.0",
+    "@pinecone-database/pinecone": "^5.1.2",
     "@types/uuid": "^9.0.8",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",


### PR DESCRIPTION
## What

Upgrades `@pinecone-database/pinecone` from `^4.1.0` to `^5.1.2` in `legal-semantic-search`.

## Why ^5 and not ^8 (latest)

This app uses `@langchain/pinecone`'s `PineconeStore` for the search route (`src/app/api/search/route.ts`). **Every** published version of `@langchain/pinecone` (through 1.0.3) declares a peer dependency of `@pinecone-database/pinecone: ^5.0.2` — none supports v6/v7/v8 yet.

Forcing v8 (via `--legacy-peer-deps`) does compile, but CI only smoke-tests the static homepage, not the `/api/search` route — so a green build would **not** catch a runtime break in the LangChain↔Pinecone integration. Since this is a sample app meant to demonstrate that integration correctly, shipping a knowing peer-dependency violation is the wrong trade. `5.1.2` is the most recent client the integration actually supports and it satisfies the peer cleanly.

**To reach v8 later:** it's gated on `@langchain/pinecone` publishing a v8-compatible release (or replacing the LangChain vector-store integration with direct Pinecone SDK calls).

## Verification

Matched the CI recipe locally (`--legacy-peer-deps`, dummy Pinecone/Voyage env):

- `npm install --legacy-peer-deps` — clean, **0 vulnerabilities**; `@pinecone-database/pinecone@5.1.2` satisfies `@langchain/pinecone`'s `^5.0.2` peer
- `npm run build` — ✓ compiled + typechecked (Next.js 16.3.0)
- `npx next start` — server boots, `/` returns HTTP 200

No application code changes: v5's `Index#upsert` still takes a bare array, so the existing call sites are unchanged.