### PR TITLE
feat: upgrade Pinecone Python client to 9.1.0 in shop-the-look

### DIFF
--- a/shop-the-look/requirements.txt
+++ b/shop-the-look/requirements.txt
@@ -1,7 +1,7 @@
 fastapi==0.133.0
 starlette==1.3.1
 uvicorn[standard]==0.32.1
-pinecone-client==4.1.0
+pinecone==9.1.0
 pydantic==2.10.4
 requests==2.33.0
 google-auth==2.29.0


### PR DESCRIPTION
## What

Upgrades shop-the-look's Python Pinecone client from the **deprecated** `pinecone-client==4.1.0` to the renamed, current package `pinecone==9.1.0`.

The `pinecone-client` PyPI package was renamed to `pinecone`; the import (`from pinecone import Pinecone`) is unchanged.

## Why

Latest Pinecone Python client, and it moves off the deprecated package name.

## No code changes required

The API surface the app uses is stable across v4→v9:

- `Pinecone(api_key=..., source_tag=...)` (`api/deps.py`)
- `pc.Index(index_name)` (`api/deps.py`)
- `index.query(vector=, top_k=, include_metadata=True)` + dict-style result access (`api/v1/endpoints/{image,video,text}.py`)

The smoke test patches `pinecone.Pinecone`, which still resolves under the new package.

## Verification

Ran the exact CI recipe locally on **Python 3.11** (the CI version):

- `pip install -r requirements.txt -r requirements-dev.txt` → installs `pinecone-9.1.0` cleanly
- `python -m pytest tests/ -q` → **1 passed** (app boots and serves root with Pinecone mocked)