### PR TITLE
ci: bump CI Node 20→22 (drop near-EOL), add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directories:
+      - "/legal-semantic-search"
+      - "/namespace-notes/client"
+      - "/namespace-notes/server"
+      - "/pinecone-assistant"
+      - "/shop-the-look"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: pip
+    directory: "/shop-the-look"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ env:
   # Dummy, non-secret placeholders. The Pinecone clients only require the key to
   # be a non-empty string at construction; no live call is made in these checks.
   PINECONE_API_KEY: pclocal-ci-dummy-key
-  NODE_VERSION: "20"
+  NODE_VERSION: "22"
 
 jobs:
   legal-semantic-search:


### PR DESCRIPTION
## What

Two standard-bar improvements for the `sample-apps` monorepo. The CI is already strong — per-app build + HTTP smoke tests, mocked Pinecone, least-privilege permissions, concurrency cancellation. This PR:

1. **Drops the near-EOL Node 20** — the shared `NODE_VERSION` env goes `20` → `22`, so every app's build/smoke job runs on a current runtime. Node 20 is the exact case we want out of CI.
2. **Adds `.github/dependabot.yml`** — covers all app manifests that previously had zero Dependabot coverage: npm across the 5 JS app dirs (including the pnpm app), pip for `shop-the-look`, and github-actions.

## Verification

- The Node 20→22 bump is exercised by each app's existing `next build` / `tsc` + HTTP smoke job — this PR's CI run validates all six apps on Node 22.
- Both YAML files validated locally.

## Follow-up (deferred)

A dependency-audit gate is worth adding but is non-trivial here (6 apps across npm/pnpm/pip, some installing with `--legacy-peer-deps`). Best added per-app or via osv-scanner in a dedicated PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)